### PR TITLE
Initial implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,10 @@ repository = "https://github.com/fizyr/subst"
 documentation = "https://docs.rs/subst"
 
 edition = "2021"
+
+[dependencies]
+memchr = "2.4.1"
+unicode-width = "0.1.9"
+
+[dev-dependencies]
+assert2 = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.1-reserved"
 license = "BSD-2-Clause OR Apache-2.0"
 repository = "https://github.com/fizyr/subst"
 documentation = "https://docs.rs/subst"
+readme = "README.md"
 
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/fizyr/subst"
 documentation = "https://docs.rs/subst"
 readme = "README.md"
 
+keywords = ["substitution", "expansion", "variable", "parameter", "shell"]
+categories = ["template-engine", "value-formatting"]
+
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # subst
 
-Shell-like variable substition for strings and byte strings.
+Shell-like variable substitution for strings and byte strings.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# subst
+
+Shell-like variable substition for strings and byte strings.
+
+## Features
+
+* Perform substitution in `&str` or in `&[u8]`.
+* Provide a custom map of variables or use environment variables.
+* Short format: `"Hello $name!"`
+* Long format: `"Hello ${name}!"`
+* Default values: `"Hello ${name:person}!"`
+* Recursive substitution in default values: `"${XDG_CONFIG_HOME:$HOME/.config}/my-app/config.toml"`
+
+Variable names can consist of alphanumeric characters and underscores.
+They are allowed to start with numbers.
+
+## Examples
+
+The [`substitute()`][substitute] function can be used to perform substitution on a `&str`.
+The variables can either be a [`HashMap`][std::collections::HashMap] or a [`BTreeMap`][std::collections::BTreeMap].
+
+```rust
+let mut variables = HashMap::new();
+variables.insert("name", "world");
+assert_eq!(subst::substitute("Hello $name!", &variables)?, "Hello world!");
+```
+
+The variables can also be taken directly from the environment with the [`Env`][Env] map.
+
+```rust
+assert_eq!(
+  subst::substitute("$XDG_CONFIG_HOME/my-app/config.toml", &subst::Env)?,
+  "/home/user/.config/my-app/config.toml",
+);
+```
+
+Substitution can also be done on byte strings using the [`substitute_bytes()`][substitute_bytes] function.
+
+```rust
+let mut variables = HashMap::new();
+variables.insert("name", b"world");
+assert_eq!(subst::substitute_bytes(b"Hello $name!", &variables)?, b"Hello world!");
+```
+
+[substitute]: https://docs.rs/subst/latest/subst/fn.substitute.html
+[substitute_bytes]: https://docs.rs/subst/latest/subst/fn.substitute_bytes.html
+[Env]: https://docs.rs/subst/latest/subst/struct.Env.html
+[std::collections::HashMap]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
+[std::collections::BTreeMap]: https://doc.rust-lang.org/stable/std/collections/struct.BTreeMap.html

--- a/README.tpl
+++ b/README.tpl
@@ -1,0 +1,9 @@
+# {{crate}}
+
+{{readme}}
+
+[substitute]: https://docs.rs/subst/latest/subst/fn.substitute.html
+[substitute_bytes]: https://docs.rs/subst/latest/subst/fn.substitute_bytes.html
+[Env]: https://docs.rs/subst/latest/subst/struct.Env.html
+[std::collections::HashMap]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html
+[std::collections::BTreeMap]: https://doc.rust-lang.org/stable/std/collections/struct.BTreeMap.html

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,142 @@
+/// An error that can occur during variable substitution.
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct Error {
+	/// The private error details.
+	inner: ErrorInner,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub(crate) enum ErrorInner {
+	InvalidEscapeSequence {
+		position: usize,
+		character: Option<u8>,
+	},
+	MissingVariableName {
+		position: usize,
+		len: usize,
+	},
+	UnexpectedCharacter {
+		position: usize,
+		character: u8,
+		expected: &'static str,
+	},
+	MissingClosingBrace {
+		position: usize,
+	},
+	NoSuchVariable {
+		position: usize,
+		name: String,
+	},
+}
+
+impl From<ErrorInner> for Error {
+	fn from(inner: ErrorInner) -> Self {
+		Self { inner }
+	}
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		match &self.inner {
+			ErrorInner::InvalidEscapeSequence { position: _, character } => {
+				if let Some(c) = character {
+					write!(f, "Invalid escape sequence: \\{}", char::from(*c))
+				} else {
+					write!(f, "Invalid escape sequence: missing escape character")
+				}
+			}
+			ErrorInner::MissingVariableName { position: _, len: _ } => {
+				write!(f, "Missing variable name")
+			},
+			ErrorInner::UnexpectedCharacter { position: _, character, expected } => {
+				write!(f, "Unexpected character: {:?}, expected {}", char::from(*character), expected)
+			},
+			ErrorInner::MissingClosingBrace { position: _ } => {
+				write!(f, "Missing closing brace")
+			},
+			ErrorInner::NoSuchVariable { position: _, name } => {
+				write!(f, "No such variable: ${name}")
+			},
+		}
+	}
+}
+
+impl Error {
+	/// Write source highlighting for the error location.
+	///
+	/// The highlighting ends with a newline.
+	pub fn write_source_highlighting(&self, f: &mut impl std::fmt::Write, source: &[u8]) -> std::fmt::Result {
+		let (line, start, len) = match &self.inner {
+			ErrorInner::InvalidEscapeSequence { position, character } => {
+				let line = get_line(source, *position);
+				if character.is_some() {
+					(line, *position, 2)
+				} else {
+					(line, *position, 1)
+				}
+			},
+			ErrorInner::MissingVariableName { position, len } => {
+				(get_line(source, *position), *position, *len)
+			},
+			ErrorInner::UnexpectedCharacter { position, character: _, expected: _ } => {
+				(get_line(source, *position), *position, 1)
+			},
+			ErrorInner::MissingClosingBrace { position } => {
+				(get_line(source, *position), *position, 1)
+			},
+			ErrorInner::NoSuchVariable { position, name } => {
+				(get_line(source, *position), *position, name.len())
+			},
+		};
+		let line = match line {
+			Ok(line) if line.len() <= 60 => line,
+			_ => return Ok(()),
+		};
+		write!(f, "  {}\n  ", line)?;
+		write_underline(f, &line, start, start + len)?;
+		writeln!(f)
+	}
+
+	/// Get source highlighting for the error location as a string.
+	///
+	/// The highlighting ends with a newline.
+	pub fn source_highlighting(&self, source: &[u8]) -> String {
+		let mut output = String::new();
+		self.write_source_highlighting(&mut output, source).unwrap();
+		output
+	}
+}
+
+fn line_start(source: &[u8], position: usize) -> usize {
+	match source[..position].iter().rposition(|&c| c == b'\n' || c == b'\r') {
+		Some(line_end) => line_end + 1,
+		None => 0,
+	}
+}
+
+fn line_end(source: &[u8], position: usize) -> usize {
+	match source[position..].iter().position(|&c| c == b'\n' || c == b'\r') {
+		Some(line_end) => position + line_end,
+		None => source.len()
+	}
+}
+
+fn get_line(source: &[u8], position: usize) -> Result<String, std::str::Utf8Error> {
+	let start = line_start(source, position);
+	let end = line_end(source, position);
+	let line = std::str::from_utf8(&source[start..end])?.trim();
+	Ok(line.replace('\t', "    "))
+}
+
+fn write_underline(f: &mut impl std::fmt::Write, line: &str, start: usize, end: usize) -> std::fmt::Result {
+	use unicode_width::UnicodeWidthStr;
+	let spaces = line[..start].width();
+	let carets = line[start..end].width();
+	write!(f, "{}", " ".repeat(spaces))?;
+	write!(f, "{}", "^".repeat(carets))?;
+	Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,496 @@
+//! Shell-like variable substition for strings and byte strings.
+//!
+//! # Example 1: String substitution using a custom variable map.
+//! ```
+//! # fn main() -> Result<(), subst::Error> {
+//! # use std::collections::HashMap;
+//! let mut variables = HashMap::new();
+//! variables.insert("name", "world");
+//! assert_eq!(subst::substitute("Hello $name!", &variables)?, "Hello world!");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Example 2: String substitution using the environment.
+//! ```
+//! # fn main() -> Result<(), subst::Error> {
+//! # std::env::set_var("XDG_CONFIG_HOME", "/home/user/.config");
+//! assert_eq!(subst::substitute("$XDG_CONFIG_HOME/my-app/config.toml", &subst::Env)?, "/home/user/.config/my-app/config.toml");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Example 3: Substitution in byte strings.
+//! ```
+//! # fn main() -> Result<(), subst::Error> {
+//! # use std::collections::HashMap;
+//! let mut variables = HashMap::new();
+//! variables.insert("name", b"world");
+//! assert_eq!(subst::substitute_bytes(b"Hello $name!", &variables)?, b"Hello world!");
+//! # Ok(())
+//! # }
+//! ```
+#![warn(missing_docs, missing_debug_implementations)]
+
+use std::borrow::Cow;
+
+mod error;
+pub use error::*;
+
+mod map;
+pub use map::*;
+
+/// Substitute variables in a string.
+///
+/// Variables have the form `$NAME`, `${NAME}` or `${NAME:default}`.
+/// A variable name can only consist of ASCII letters, digits and underscores.
+/// They are allowed to start with numbers.
+///
+/// You can escape dollar signs, backslashes, colons and braces with a backlash.
+///
+/// You can pass either a [`HashMap`][std::collections::HashMap], [`BTreeMap`][std::collections::BTreeMap] or [`Env`] as the `variables` parameter.
+/// The maps must have [`&str`] or [`String`] keys, and the values must be [`AsRef<str>`].
+pub fn substitute<'a, M>(source: &str, variables: &'a M) -> Result<String, Error>
+where
+	M: VariableMap<'a>,
+	M::Value: AsRef<str>,
+{
+	let output = substitute_impl(source.as_bytes(), variables, |x| x.as_ref().as_bytes())?;
+	// SAFETY: Both source and all variable values are valid UTF-8, so substitation result is also valid UTF-8.
+	unsafe {
+		Ok(String::from_utf8_unchecked(output))
+	}
+}
+
+/// Substitute variables in a byte string.
+///
+/// Variables have the form `$NAME`, `${NAME}` or `${NAME:default}`.
+/// A variable name can only consist of ASCII letters, digits and underscores.
+/// They are allowed to start with numbers.
+///
+/// You can escape dollar signs, backslashes, colons and braces with a backlash.
+///
+/// You can pass either a [`HashMap`][std::collections::HashMap], [`BTreeMap`][std::collections::BTreeMap] as the `variables` parameter.
+/// The maps must have [`&str`] or [`String`] keys, and the values must be [`AsRef<[u8]>`].
+/// On Unix platforms, you can also use [`EnvBytes`].
+pub fn substitute_bytes<'a, M>(source: &[u8], variables: &'a M) -> Result<Vec<u8>, Error>
+where
+	M: VariableMap<'a>,
+	M::Value: AsRef<[u8]>,
+{
+	substitute_impl(source, variables, |x| x.as_ref())
+}
+
+/// Substitute variables in a byte string.
+///
+/// This is the real implementation used by both [`substitute`] and [`substitute_bytes`].
+/// The function accepts any type that implements [`VariableMap`], and a function to convert the value from the map into bytes.
+fn substitute_impl<'a, M, F>(source: &[u8], variables: &'a M, to_bytes: F) -> Result<Vec<u8>, Error>
+where
+	M: VariableMap<'a>,
+	F: Fn(&M::Value) -> &[u8],
+{
+	let mut finger = 0;
+	let mut output = Vec::with_capacity(source.len() + source.len() / 10);
+	while finger < source.len() {
+		let next = match memchr::memchr2(b'$', b'\\', &source[finger..]) {
+			Some(x) => finger + x,
+			None => break,
+		};
+
+		output.extend_from_slice(&source[finger..next]);
+		if source[next] == b'\\' {
+			output.push(unescape_one(source, next)?);
+			finger = next + 2;
+		} else {
+			let variable = parse_variable(source, next)?;
+			let default = variable.default.as_ref().map(|x| x.as_ref());
+			dbg!(&variable);
+			let value = variables.get(variable.name);
+			let value = dbg!(value
+				.as_ref()
+				.map(&to_bytes))
+				.or(default)
+				.ok_or_else(|| ErrorInner::NoSuchVariable {
+					position: variable.name_start,
+					name: variable.name.to_owned(),
+				})?;
+			output.extend_from_slice(value);
+			finger = variable.end_position;
+		}
+	}
+
+	output.extend_from_slice(&source[finger..]);
+	Ok(output)
+}
+
+
+/// A parsed variable.
+#[derive(Debug)]
+struct Variable<'a> {
+	/// The name of the variable.
+	name: &'a str,
+
+	/// The start position of the name in the source.
+	name_start: usize,
+
+	/// The default value of the variable.
+	default: Option<Cow<'a, [u8]>>,
+
+	/// The end position of the entire variable in the source.
+	end_position: usize,
+}
+
+/// Parse a variable from source at the given position.
+///
+/// The finger must be the position of the dollar sign in the source.
+fn parse_variable(source: &[u8], finger: usize) -> Result<Variable, Error> {
+	if finger == source.len() {
+		return Err(ErrorInner::MissingVariableName {
+			position: finger,
+			len: 1,
+		}.into())
+	}
+	if source[finger + 1] == b'{' {
+		parse_braced_variable(source, finger)
+	} else {
+		let name_end = match source[finger + 1..].iter().position(|&c| !c.is_ascii_alphanumeric() && c != b'_') {
+			Some(0) => return Err(ErrorInner::MissingVariableName {
+				position: finger,
+				len: 1,
+			}.into()),
+			Some(x) => finger + 1 + x,
+			None => source.len(),
+		};
+		Ok(Variable {
+			name: std::str::from_utf8(&source[finger + 1..name_end]).unwrap(),
+			name_start: finger + 1,
+			default: None,
+			end_position: name_end,
+		})
+	}
+}
+
+/// Parse a braced variable in the form of "${name[:default]} from source at the given position.
+///
+/// The finger must be the position of the dollar sign in the source.
+fn parse_braced_variable(source: &[u8], finger: usize) -> Result<Variable, Error> {
+	let name_start = finger + 2;
+	if name_start >= source.len() {
+		return Err(ErrorInner::MissingVariableName {
+			position: finger,
+			len: 2,
+		}.into())
+	}
+
+	// Get the first sequence of alphanumeric characters and underscores for the variable name.
+	let name_end = match source[name_start..].iter().position(|&c| !c.is_ascii_alphanumeric() && c != b'_') {
+		Some(0) => return Err(ErrorInner::MissingVariableName {
+			position: finger,
+			len: 2,
+		}.into()),
+		Some(x) => name_start + x,
+		None => source.len(),
+	};
+
+	// If the name extends to the end, we're missing a closing brace.
+	if name_end == source.len() {
+		return Err(ErrorInner::MissingClosingBrace {
+			position: finger + 1,
+		}.into())
+	}
+
+	// If there is a closing brace after the name, there is no default value and we're done.
+	if source[name_end] == b'}' {
+		return Ok(Variable {
+			name: std::str::from_utf8(&source[name_start..name_end]).unwrap(),
+			name_start,
+			default: None,
+			end_position: name_end + 1,
+		});
+
+	// If there is something other than a closing brace or colon after the name, it's an error.
+	} else if source[name_end] != b':' {
+		return Err(ErrorInner::UnexpectedCharacter {
+			position: name_end,
+			character: source[name_end],
+			expected: "a closing brace ('}') or colon (':')",
+		}.into());
+	}
+
+	// If there is no un-escaped closing brace, it's missing.
+	let end = finger + find_non_escaped(b'}', &source[finger..])
+		.ok_or_else(|| ErrorInner::MissingClosingBrace {
+			position: finger + 1,
+		})?;
+
+	let default = unescape(source, name_end + 1, end)?;
+	Ok(Variable {
+		name: std::str::from_utf8(&source[name_start..name_end]).unwrap(),
+		name_start,
+		default: Some(default),
+		end_position: end + 1,
+	})
+}
+
+/// Find the first non-escaped occurence of a character.
+fn find_non_escaped(needle: u8, haystack: &[u8]) -> Option<usize> {
+	let mut finger = 0;
+	while finger < haystack.len() {
+		let candidate = memchr::memchr2(b'\\', needle, &haystack[finger..])?;
+		if haystack[finger + candidate] == b'\\' {
+			if candidate == haystack.len() - 1 {
+				return None;
+			}
+			finger += candidate + 2;
+		} else {
+			return Some(finger + candidate)
+		}
+	}
+	None
+}
+
+/// Unescape a byte string.
+///
+/// Only valid escape sequences ('\$' '\{' '\}' and '\:') are accepted.
+/// Invalid escape sequences cause an error to be returned.
+///
+/// If the input contains no escape sequences, it is returned unmodified without copying the data.
+fn unescape(source: &[u8], start: usize, end: usize) -> Result<Cow<[u8]>, Error> {
+	// Check if there is any escape character.
+	// If not, just return the borrowed input.
+	let mut finger = match memchr::memchr(b'\\', &source[start..end]) {
+		None => return Ok(Cow::Borrowed(&source[start..end])),
+		Some(x) => start + x,
+	};
+
+	// There was atleast one backslash, so we have to return an owned vector.
+	// Fill it until the first escape sequence.
+	let mut output = Vec::with_capacity(end - start);
+	output.extend_from_slice(&source[start..finger]);
+	output.push(unescape_one(&source[..end], finger)?);
+	finger += 2;
+
+	// Keep parsing escape sequences until the input is consumed.
+	while finger < end {
+		match memchr::memchr(b'\\', &source[finger..end]) {
+			None => {
+				output.extend_from_slice(&source[finger..end]);
+				finger = end;
+			},
+			Some(x) => {
+				let position = finger + x;
+				output.extend_from_slice(&source[finger..position]);
+				output.push(unescape_one(&source[..end], position)?);
+				finger = position + 2;
+			},
+		}
+	}
+
+	Ok(Cow::Owned(output))
+}
+
+/// Unescape a single escape sequence in source at the given position.
+///
+/// Only valid escape sequences ('\$' '\{' '\}' and '\:') are accepted.
+/// Invalid escape sequences cause an error to be returned.
+fn unescape_one(source: &[u8], position: usize) -> Result<u8, Error> {
+	if position == source.len() - 1 {
+		return Err(ErrorInner::InvalidEscapeSequence {
+			position,
+			character: None,
+		}.into())
+	}
+	match source[position + 1] {
+		b'\\' => Ok(b'\\'),
+		b'$' => Ok(b'$'),
+		b'{' => Ok(b'{'),
+		b'}' => Ok(b'}'),
+		b':' => Ok(b':'),
+		other => Err(ErrorInner::InvalidEscapeSequence {
+			position,
+			character: Some(other),
+		}.into())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use std::collections::BTreeMap;
+	use assert2::{assert, check, let_assert};
+	use super::*;
+
+	#[test]
+	fn test_unescape_borrows_when_possible() {
+		let_assert!(Ok(Cow::Borrowed(b"foo bar")) = unescape(b"foo bar", 0, 7));
+	}
+
+	#[test]
+	fn test_unescape() {
+		let_assert!(Ok(Cow::Owned(unescaped)) = unescape(b"foo \\\\\\$b\\{ar\\}", 0, 15));
+		check!(unescaped == b"foo \\$b{ar}");
+		check!(unescape(b"foo\\", 0, 4) == Err(ErrorInner::InvalidEscapeSequence {
+			position: 3,
+			character: None,
+		}.into()));
+		check!(unescape(b"foo \\bar", 0, 8) == Err(ErrorInner::InvalidEscapeSequence {
+			position: 4,
+			character: Some(b'b'),
+		}.into()));
+	}
+
+	#[test]
+	fn test_find_non_escaped() {
+		check!(find_non_escaped(b'$', b"$foo") == Some(0));
+		check!(find_non_escaped(b'$', b"\\$foo$") == Some(5));
+		check!(find_non_escaped(b'$', b"foo $bar") == Some(4));
+		check!(find_non_escaped(b'$', b"foo \\$$bar") == Some(6));
+	}
+
+	#[test]
+	fn test_substitute() {
+		let mut map: BTreeMap<String, String> = BTreeMap::new();
+		map.insert("name".into(), "world".into());
+		check!(let Ok("Hello world!") = substitute("Hello $name!", &map).as_deref());
+		check!(let Ok("Hello world!") = substitute("Hello ${name}!", &map).as_deref());
+		check!(let Ok("Hello world!") = substitute("Hello ${name:not-world}!", &map).as_deref());
+		check!(let Ok("Hello world!") = substitute("Hello ${not_name:world}!", &map).as_deref());
+
+		let mut map: BTreeMap<&str, &str> = BTreeMap::new();
+		map.insert("name", "world");
+		check!(let Ok("Hello world!") = substitute("Hello $name!", &map).as_deref());
+		check!(let Ok("Hello world!") = substitute("Hello ${name}!", &map).as_deref());
+		check!(let Ok("Hello world!") = substitute("Hello ${name:not-world}!", &map).as_deref());
+		check!(let Ok("Hello world!") = substitute("Hello ${not_name:world}!", &map).as_deref());
+	}
+
+	#[test]
+	fn test_substitute_bytes() {
+		let mut map: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+		map.insert("name".into(), b"world"[..].into());
+		check!(let Ok(b"Hello world!") = substitute_bytes(b"Hello $name!", &map).as_deref());
+		check!(let Ok(b"Hello world!") = substitute_bytes(b"Hello ${name}!", &map).as_deref());
+		check!(let Ok(b"Hello world!") = substitute_bytes(b"Hello ${name:not-world}!", &map).as_deref());
+		check!(let Ok(b"Hello world!") = substitute_bytes(b"Hello ${not_name:world}!", &map).as_deref());
+
+		let mut map: BTreeMap<&str, &[u8]> = BTreeMap::new();
+		map.insert("name", b"world");
+		check!(let Ok(b"Hello world!") = substitute_bytes(b"Hello $name!", &map).as_deref());
+		check!(let Ok(b"Hello world!") = substitute_bytes(b"Hello ${name}!", &map).as_deref());
+		check!(let Ok(b"Hello world!") = substitute_bytes(b"Hello ${name:not-world}!", &map).as_deref());
+		check!(let Ok(b"Hello world!") = substitute_bytes(b"Hello ${not_name:world}!", &map).as_deref());
+	}
+
+	#[test]
+	fn test_invalid_escape_sequence() {
+		let map: BTreeMap<String, String> = BTreeMap::new();
+
+		let source = br"Hello \world!";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == r"Invalid escape sequence: \w");
+		assert!(e.source_highlighting(source) == concat!(
+				r"  Hello \world!", "\n",
+				r"        ^^", "\n",
+		));
+
+		let source = br"Hello world!\";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == r"Invalid escape sequence: missing escape character");
+		assert!(e.source_highlighting(source) == concat!(
+				r"  Hello world!\", "\n",
+				r"              ^", "\n",
+		));
+	}
+
+	#[test]
+	fn test_missing_variable_name() {
+		let map: BTreeMap<String, String> = BTreeMap::new();
+
+		let source = br"Hello $!";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == r"Missing variable name");
+		assert!(e.source_highlighting(source) == concat!(
+				r"  Hello $!", "\n",
+				r"        ^", "\n",
+		));
+
+		let source = br"Hello ${}!";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == r"Missing variable name");
+		assert!(e.source_highlighting(source) == concat!(
+				r"  Hello ${}!", "\n",
+				r"        ^^", "\n",
+		));
+
+		let source = br"Hello ${:fallback}!";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == r"Missing variable name");
+		assert!(e.source_highlighting(source) == concat!(
+				r"  Hello ${:fallback}!", "\n",
+				r"        ^^", "\n",
+		));
+	}
+
+	#[test]
+	fn test_unexpected_character() {
+		let map: BTreeMap<String, String> = BTreeMap::new();
+
+		let source = b"Hello ${name)!";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == "Unexpected character: ')', expected a closing brace ('}') or colon (':')");
+		assert!(e.source_highlighting(source) == concat!(
+				"  Hello ${name)!\n",
+				"              ^\n",
+		));
+
+		let source = b"Hello $name!";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == "No such variable: $name");
+		assert!(e.source_highlighting(source) == concat!(
+				"  Hello $name!\n",
+				"         ^^^^\n",
+		));
+	}
+
+	#[test]
+	fn test_missing_closing_brace() {
+		let map: BTreeMap<String, String> = BTreeMap::new();
+
+		let source = b"Hello ${name";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == "Missing closing brace");
+		assert!(e.source_highlighting(source) == concat!(
+				"  Hello ${name\n",
+				"         ^\n",
+		));
+
+		let source = b"Hello ${name:fallback";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == "Missing closing brace");
+		assert!(e.source_highlighting(source) == concat!(
+				"  Hello ${name:fallback\n",
+				"         ^\n",
+		));
+	}
+
+	#[test]
+	fn test_substitute_no_such_variable() {
+		let map: BTreeMap<String, String> = BTreeMap::new();
+
+		let source = b"Hello ${name}!";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == "No such variable: $name");
+		assert!(e.source_highlighting(source) == concat!(
+				"  Hello ${name}!\n",
+				"          ^^^^\n",
+		));
+
+		let source = b"Hello $name!";
+		let_assert!(Err(e) = substitute_bytes(source, &map));
+		assert!(e.to_string() == "No such variable: $name");
+		assert!(e.source_highlighting(source) == concat!(
+				"  Hello $name!\n",
+				"         ^^^^\n",
+		));
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@
 //!
 //! # Examples
 //!
-//! The [`substitute()`] function can be used to perform substitution on [`&str`].
-//! The variables can either be a [`HashMap`](std::collections::HashMap) or a [`BTreeMap`](std::collections::BTreeMap).
+//! The [`substitute()`][substitute] function can be used to perform substitution on a `&str`.
+//! The variables can either be a [`HashMap`][std::collections::HashMap] or a [`BTreeMap`][std::collections::BTreeMap].
 //!
 //! ```
 //! # fn main() -> Result<(), subst::Error> {
@@ -27,7 +27,7 @@
 //! # }
 //! ```
 //!
-//! The variables can also be taken directly from the environment with the [`Env`] map.
+//! The variables can also be taken directly from the environment with the [`Env`][Env] map.
 //!
 //! ```
 //! # fn main() -> Result<(), subst::Error> {
@@ -40,7 +40,7 @@
 //! # }
 //! ```
 //!
-//! Substitution can also be done on byte strings using the [`substitute_bytes()`] function.
+//! Substitution can also be done on byte strings using the [`substitute_bytes()`][substitute_bytes] function.
 //!
 //! ```
 //! # fn main() -> Result<(), subst::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Shell-like variable substition for strings and byte strings.
+//! Shell-like variable substitution for strings and byte strings.
 //!
 //! # Features
 //!
@@ -65,7 +65,7 @@ pub use map::*;
 /// A variable name can only consist of ASCII letters, digits and underscores.
 /// They are allowed to start with numbers.
 ///
-/// You can escape dollar signs, backslashes, colons and braces with a backlash.
+/// You can escape dollar signs, backslashes, colons and braces with a backslash.
 ///
 /// You can pass either a [`HashMap`][std::collections::HashMap], [`BTreeMap`][std::collections::BTreeMap] or [`Env`] as the `variables` parameter.
 /// The maps must have [`&str`] or [`String`] keys, and the values must be [`AsRef<str>`].
@@ -88,7 +88,7 @@ where
 /// A variable name can only consist of ASCII letters, digits and underscores.
 /// They are allowed to start with numbers.
 ///
-/// You can escape dollar signs, backslashes, colons and braces with a backlash.
+/// You can escape dollar signs, backslashes, colons and braces with a backslash.
 ///
 /// You can pass either a [`HashMap`][std::collections::HashMap], [`BTreeMap`][std::collections::BTreeMap] as the `variables` parameter.
 /// The maps must have [`&str`] or [`String`] keys, and the values must be [`AsRef<[u8]>`].
@@ -254,7 +254,7 @@ fn parse_braced_variable(source: &[u8], finger: usize) -> Result<Variable, Error
 	})
 }
 
-/// Find the first non-escaped occurence of a character.
+/// Find the first non-escaped occurrence of a character.
 fn find_non_escaped(needle: u8, haystack: &[u8]) -> Option<usize> {
 	let mut finger = 0;
 	while finger < haystack.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,22 @@
 //! Shell-like variable substition for strings and byte strings.
 //!
-//! # Example 1: String substitution using a custom variable map.
+//! # Features
+//!
+//! * Perform substitution in `&str` or in `&[u8]`.
+//! * Provide a custom map of variables or use environment variables.
+//! * Short format: `"Hello $name!"`
+//! * Long format: `"Hello ${name}!"`
+//! * Default values: `"Hello ${name:person}!"`
+//! * Recursive substitution in default values: `"${XDG_CONFIG_HOME:$HOME/.config}/my-app/config.toml"`
+//!
+//! Variable names can consist of alphanumeric characters and underscores.
+//! They are allowed to start with numbers.
+//!
+//! # Examples
+//!
+//! The [`substitute()`] function can be used to perform substitution on [`&str`].
+//! The variables can either be a [`HashMap`](std::collections::HashMap) or a [`BTreeMap`](std::collections::BTreeMap).
+//!
 //! ```
 //! # fn main() -> Result<(), subst::Error> {
 //! # use std::collections::HashMap;
@@ -11,16 +27,21 @@
 //! # }
 //! ```
 //!
-//! # Example 2: String substitution using the environment.
+//! The variables can also be taken directly from the environment with the [`Env`] map.
+//!
 //! ```
 //! # fn main() -> Result<(), subst::Error> {
 //! # std::env::set_var("XDG_CONFIG_HOME", "/home/user/.config");
-//! assert_eq!(subst::substitute("$XDG_CONFIG_HOME/my-app/config.toml", &subst::Env)?, "/home/user/.config/my-app/config.toml");
+//! assert_eq!(
+//!   subst::substitute("$XDG_CONFIG_HOME/my-app/config.toml", &subst::Env)?,
+//!   "/home/user/.config/my-app/config.toml",
+//! );
 //! # Ok(())
 //! # }
 //! ```
 //!
-//! # Example 3: Substitution in byte strings.
+//! Substitution can also be done on byte strings using the [`substitute_bytes()`] function.
+//!
 //! ```
 //! # fn main() -> Result<(), subst::Error> {
 //! # use std::collections::HashMap;

--- a/src/map.rs
+++ b/src/map.rs
@@ -23,7 +23,7 @@ impl<'a> VariableMap<'a> for Env {
 
 /// A map that gives byte strings from the environment.
 ///
-/// Only available on unix platforms.
+/// Only available on Unix platforms.
 #[cfg(unix)]
 #[derive(Debug)]
 pub struct EnvBytes;

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,0 +1,72 @@
+use std::collections::{BTreeMap, HashMap};
+
+/// Trait for types that can be used as a variable map.
+pub trait VariableMap<'a> {
+	/// The type returned by the [`get()`][Self::get] function.
+	type Value;
+
+	/// Get a value from the map.
+	fn get(&'a self, key: &str) -> Option<Self::Value>;
+}
+
+/// A map that gives strings from the environment.
+#[derive(Debug)]
+pub struct Env;
+
+impl<'a> VariableMap<'a> for Env {
+	type Value = String;
+
+	fn get(&'a self, key: &str) -> Option<Self::Value> {
+		std::env::var(key).ok()
+	}
+}
+
+/// A map that gives byte strings from the environment.
+///
+/// Only available on unix platforms.
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct EnvBytes;
+
+#[cfg(unix)]
+impl<'a> VariableMap<'a> for EnvBytes {
+	type Value = Vec<u8>;
+
+	fn get(&'a self, key: &str) -> Option<Self::Value> {
+		use std::os::unix::ffi::OsStringExt;
+		let value = std::env::var_os(key)?;
+		Some(value.into_vec())
+	}
+}
+
+impl<'a, V: 'a> VariableMap<'a> for BTreeMap<&str, V> {
+	type Value = &'a V;
+
+	fn get(&'a self, key: &str) -> Option<Self::Value> {
+		self.get(key)
+	}
+}
+
+impl<'a, V: 'a> VariableMap<'a> for BTreeMap<String, V> {
+	type Value = &'a V;
+
+	fn get(&'a self, key: &str) -> Option<Self::Value> {
+		self.get(key)
+	}
+}
+
+impl<'a, V: 'a> VariableMap<'a> for HashMap<&str, V> {
+	type Value = &'a V;
+
+	fn get(&'a self, key: &str) -> Option<Self::Value> {
+		self.get(key)
+	}
+}
+
+impl<'a, V: 'a> VariableMap<'a> for HashMap<String, V> {
+	type Value = &'a V;
+
+	fn get(&'a self, key: &str) -> Option<Self::Value> {
+		self.get(key)
+	}
+}


### PR DESCRIPTION
This PR implements variable substitution for `&str` and `&[u8]`. You can use either a custom map with your own variables, or `Env` or `EnvBytes` to directly use environment variables.

In the long syntax, you can give default values: `${hello:bar}`. You can even have variables in the default value: `${XDG_CONFIG_HOME:$HOME/.config}/my-app/config.toml`.