### PR TITLE
Add support for variable substitution in YAML data.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,5 @@
+# Unreleased
+- [add][minor] Add support for substitution in all string values of YAML data.
+
 # Version 0.1.0 - 2022-02-22
 - [add][major] Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,19 @@ categories = ["template-engine", "value-formatting"]
 
 edition = "2021"
 
+[features]
+yaml = ["serde", "serde_yaml"]
+
 [dependencies]
 memchr = "2.4.1"
+serde = { version = "1.0.0", optional = true }
+serde_yaml = { version = "0.8.23", optional = true }
 unicode-width = "0.1.9"
 
 [dev-dependencies]
 assert2 = "0.3.6"
+subst = { path = ".", features = ["yaml"] }
+serde = { version = "1.0.0", features = ["derive"] }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Shell-like variable substitution for strings and byte strings.
 * Long format: `"Hello ${name}!"`
 * Default values: `"Hello ${name:person}!"`
 * Recursive substitution in default values: `"${XDG_CONFIG_HOME:$HOME/.config}/my-app/config.toml"`
+* Perform substitution on all string values in YAML data (optional, requires the `yaml` feature).
 
 Variable names can consist of alphanumeric characters and underscores.
 They are allowed to start with numbers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! * Long format: `"Hello ${name}!"`
 //! * Default values: `"Hello ${name:person}!"`
 //! * Recursive substitution in default values: `"${XDG_CONFIG_HOME:$HOME/.config}/my-app/config.toml"`
+//! * Perform substitution on all string values in YAML data (optional, requires the `yaml` feature).
 //!
 //! Variable names can consist of alphanumeric characters and underscores.
 //! They are allowed to start with numbers.
@@ -58,6 +59,9 @@ pub use error::*;
 
 mod map;
 pub use map::*;
+
+#[cfg(feature = "yaml")]
+pub mod yaml;
 
 /// Substitute variables in a string.
 ///

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -1,0 +1,137 @@
+//! Support for variable substitution in YAML data.
+
+use serde::de::DeserializeOwned;
+
+use crate::VariableMap;
+
+/// Parse a struct from YAML data, after perfoming variable substitution on string values.
+///
+/// This function first parses the data into a [`serde_yaml::Value`],
+/// then performs variable substitution on all string values,
+/// and then parses it further into the desired type.
+pub fn from_slice<'a, T: DeserializeOwned, M>(data: &[u8], variables: &'a M) -> Result<T, Error>
+where
+	M: VariableMap<'a>,
+	M::Value: AsRef<str>,
+{
+	let mut value: serde_yaml::Value = serde_yaml::from_slice(data)?;
+	substitute_string_values(&mut value, variables)?;
+	Ok(serde_yaml::from_value(value)?)
+}
+
+/// Parse a struct from YAML data, after perfoming variable substitution on string values.
+///
+/// This function first parses the data into a [`serde_yaml::Value`],
+/// then performs variable substitution on all string values,
+/// and then parses it further into the desired type.
+pub fn from_str<'a, T: DeserializeOwned, M>(data: &str, variables: &'a M) -> Result<T, Error>
+where
+	M: VariableMap<'a>,
+	M::Value: AsRef<str>,
+{
+	let mut value: serde_yaml::Value = serde_yaml::from_str(data)?;
+	substitute_string_values(&mut value, variables)?;
+	Ok(serde_yaml::from_value(value)?)
+}
+
+/// Perform variable substitution on string values of a YAML value.
+pub fn substitute_string_values<'a, M>(value: &mut serde_yaml::Value, variables: &'a M) -> Result<(), crate::Error>
+where
+	M: VariableMap<'a>,
+	M::Value: AsRef<str>,
+{
+	visit_string_values(value, |value| {
+		*value = crate::substitute(value.as_str(), variables)?;
+		Ok(())
+	})
+}
+
+/// Error for parsing YAML with variable substitution.
+#[derive(Debug)]
+pub enum Error {
+	/// An error occured while parsing YAML.
+	Yaml(serde_yaml::Error),
+
+	/// An error occured while performing variable substitution.
+	Subst(crate::Error),
+}
+
+impl From<serde_yaml::Error> for Error {
+	fn from(other: serde_yaml::Error) -> Self {
+		Self::Yaml(other)
+	}
+}
+
+impl From<crate::Error> for Error {
+	fn from(other: crate::Error) -> Self {
+		Self::Subst(other)
+	}
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Error::Yaml(e) => std::fmt::Display::fmt(e, f),
+			Error::Subst(e) => std::fmt::Display::fmt(e, f),
+		}
+	}
+}
+
+/// Recursively apply a function to all string values in a YAML value.
+fn visit_string_values<F, E>(value: &mut serde_yaml::Value, fun: F) -> Result<(), E>
+where
+	F: Copy + Fn(&mut String) -> Result<(), E>,
+{
+	match value {
+		serde_yaml::Value::Null => Ok(()),
+		serde_yaml::Value::Bool(_) => Ok(()),
+		serde_yaml::Value::Number(_) => Ok(()),
+		serde_yaml::Value::String(val) => fun(val),
+		serde_yaml::Value::Sequence(seq) => {
+			for value in seq {
+				visit_string_values(value, fun)?;
+			}
+			Ok(())
+		},
+		serde_yaml::Value::Mapping(map) => {
+			for (_key, value) in map.iter_mut() {
+				visit_string_values(value, fun)?;
+			}
+			Ok(())
+		},
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use std::collections::HashMap;
+
+	use super::*;
+	use assert2::{assert, let_assert};
+
+	#[test]
+	fn test_from_str() {
+		#[derive(Debug, serde::Deserialize)]
+		struct Struct {
+			bar: String,
+			baz: String,
+		}
+
+		let mut variables = HashMap::new();
+		variables.insert("bar", "aap");
+		variables.insert("baz", "noot");
+		let_assert!(Ok(parsed) = from_str(
+			concat!(
+				"bar: $bar\n",
+				"baz: $baz/with/stuff\n",
+			),
+			&variables,
+		));
+
+		let parsed: Struct = parsed;
+		assert!(parsed.bar == "aap");
+		assert!(parsed.baz == "noot/with/stuff");
+	}
+}

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -134,4 +134,28 @@ mod test {
 		assert!(parsed.bar == "aap");
 		assert!(parsed.baz == "noot/with/stuff");
 	}
+
+	#[test]
+	fn test_yaml_in_var_is_not_parsed() {
+		#[derive(Debug, serde::Deserialize)]
+		struct Struct {
+			bar: String,
+			baz: String,
+		}
+
+		let mut variables = HashMap::new();
+		variables.insert("bar", "aap\nbaz: mies");
+		variables.insert("baz", "noot");
+		let_assert!(Ok(parsed) = from_str(
+			concat!(
+				"bar: $bar\n",
+				"baz: $baz\n",
+			),
+			&variables,
+		));
+
+		let parsed: Struct = parsed;
+		assert!(parsed.bar == "aap\nbaz: mies");
+		assert!(parsed.baz == "noot");
+	}
 }


### PR DESCRIPTION
This PR adds supports for performing variable substitution on all string values in YAML data. It's added as optional feature to avoid pulling in `serde` and `serde_yaml` when the feature is not needed.

I still have to update the changelog, but it appears that I released this crate at home and didn't push the 0.1.0 release (including changelog) yet. I will fix this when I get back home, but for now, you can review the implementation.