### PR TITLE
Refactor to fully support UTF-8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2018"
 yaml = ["serde", "serde_yaml"]
 
 [dependencies]
+bstr = { version = "1.6.0", default-features = false, features = ["std"] }
 memchr = "2.4.1"
 serde = { version = "1.0.0", optional = true }
 serde_yaml = { version = "0.9.13", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,30 +21,35 @@ pub enum Error {
 }
 
 impl From<InvalidEscapeSequence> for Error {
+	#[inline]
 	fn from(other: InvalidEscapeSequence) -> Self {
 		Self::InvalidEscapeSequence(other)
 	}
 }
 
 impl From<MissingVariableName> for Error {
+	#[inline]
 	fn from(other: MissingVariableName) -> Self {
 		Self::MissingVariableName(other)
 	}
 }
 
 impl From<UnexpectedCharacter> for Error {
+	#[inline]
 	fn from(other: UnexpectedCharacter) -> Self {
 		Self::UnexpectedCharacter(other)
 	}
 }
 
 impl From<MissingClosingBrace> for Error {
+	#[inline]
 	fn from(other: MissingClosingBrace) -> Self {
 		Self::MissingClosingBrace(other)
 	}
 }
 
 impl From<NoSuchVariable> for Error {
+	#[inline]
 	fn from(other: NoSuchVariable) -> Self {
 		Self::NoSuchVariable(other)
 	}
@@ -53,6 +58,7 @@ impl From<NoSuchVariable> for Error {
 impl std::error::Error for Error {}
 
 impl std::fmt::Display for Error {
+	#[inline]
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		match self {
 			Self::InvalidEscapeSequence(e) => e.fmt(f),
@@ -80,6 +86,7 @@ pub struct InvalidEscapeSequence {
 impl std::error::Error for InvalidEscapeSequence {}
 
 impl std::fmt::Display for InvalidEscapeSequence {
+	#[inline]
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		if let Some(c) = self.character {
 			write!(f, "Invalid escape sequence: \\{}", c)
@@ -105,6 +112,7 @@ pub struct MissingVariableName {
 impl std::error::Error for MissingVariableName {}
 
 impl std::fmt::Display for MissingVariableName {
+	#[inline]
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(f, "Missing variable name")
 	}
@@ -129,6 +137,7 @@ pub struct UnexpectedCharacter {
 impl std::error::Error for UnexpectedCharacter {}
 
 impl std::fmt::Display for UnexpectedCharacter {
+	#[inline]
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(f, "Unexpected character: {:?}, expected {}", self.character, self.expected.message())
 	}
@@ -162,6 +171,7 @@ pub struct MissingClosingBrace {
 impl std::error::Error for MissingClosingBrace {}
 
 impl std::fmt::Display for MissingClosingBrace {
+	#[inline]
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(f, "Missing closing brace")
 	}
@@ -183,6 +193,7 @@ pub struct NoSuchVariable {
 impl std::error::Error for NoSuchVariable {}
 
 impl std::fmt::Display for NoSuchVariable {
+	#[inline]
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(f, "No such variable: ${}", self.name)
 	}
@@ -250,6 +261,7 @@ impl Error {
 	/// The highlighting ends with a newline.
 	///
 	/// Note: this function returns an empty string if the source line exceeds 60 characters in width.
+	#[inline]
 	pub fn source_highlighting(&self, source: &str) -> String {
 		let mut output = String::new();
 		self.write_source_highlighting(&mut output, source).unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,39 +1,52 @@
+//! Module containing error details.
+
 /// An error that can occur during variable substitution.
 #[derive(Debug, Clone)]
 #[cfg_attr(test, derive(Eq, PartialEq))]
-pub struct Error {
-	/// The private error details.
-	inner: ErrorInner,
+pub enum Error {
+	/// The input string contains an invalid escape sequence.
+	InvalidEscapeSequence(InvalidEscapeSequence),
+
+	/// The input string contains a variable placeholder without a variable name (`"${}"`).
+	MissingVariableName(MissingVariableName),
+
+	/// The input string contains an unexpected character.
+	UnexpectedCharacter(UnexpectedCharacter),
+
+	/// The input string contains an unclosed variable placeholder.
+	MissingClosingBrace(MissingClosingBrace),
+
+	/// The input string contains a placeholder for a variable that is not in the variable map.
+	NoSuchVariable(NoSuchVariable),
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
-pub(crate) enum ErrorInner {
-	InvalidEscapeSequence {
-		position: usize,
-		character: Option<u8>,
-	},
-	MissingVariableName {
-		position: usize,
-		len: usize,
-	},
-	UnexpectedCharacter {
-		position: usize,
-		character: u8,
-		expected: &'static str,
-	},
-	MissingClosingBrace {
-		position: usize,
-	},
-	NoSuchVariable {
-		position: usize,
-		name: String,
-	},
+impl From<InvalidEscapeSequence> for Error {
+	fn from(other: InvalidEscapeSequence) -> Self {
+		Self::InvalidEscapeSequence(other)
+	}
 }
 
-impl From<ErrorInner> for Error {
-	fn from(inner: ErrorInner) -> Self {
-		Self { inner }
+impl From<MissingVariableName> for Error {
+	fn from(other: MissingVariableName) -> Self {
+		Self::MissingVariableName(other)
+	}
+}
+
+impl From<UnexpectedCharacter> for Error {
+	fn from(other: UnexpectedCharacter) -> Self {
+		Self::UnexpectedCharacter(other)
+	}
+}
+
+impl From<MissingClosingBrace> for Error {
+	fn from(other: MissingClosingBrace) -> Self {
+		Self::MissingClosingBrace(other)
+	}
+}
+
+impl From<NoSuchVariable> for Error {
+	fn from(other: NoSuchVariable) -> Self {
+		Self::NoSuchVariable(other)
 	}
 }
 
@@ -41,63 +54,204 @@ impl std::error::Error for Error {}
 
 impl std::fmt::Display for Error {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		match &self.inner {
-			ErrorInner::InvalidEscapeSequence { position: _, character } => {
-				if let Some(c) = character {
-					write!(f, "Invalid escape sequence: \\{}", char::from(*c))
-				} else {
-					write!(f, "Invalid escape sequence: missing escape character")
-				}
-			}
-			ErrorInner::MissingVariableName { position: _, len: _ } => {
-				write!(f, "Missing variable name")
-			},
-			ErrorInner::UnexpectedCharacter { position: _, character, expected } => {
-				write!(f, "Unexpected character: {:?}, expected {}", char::from(*character), expected)
-			},
-			ErrorInner::MissingClosingBrace { position: _ } => {
-				write!(f, "Missing closing brace")
-			},
-			ErrorInner::NoSuchVariable { position: _, name } => {
-				write!(f, "No such variable: ${}", name)
-			},
+		match self {
+			Self::InvalidEscapeSequence(e) => e.fmt(f),
+			Self::MissingVariableName(e) => e.fmt(f),
+			Self::UnexpectedCharacter(e) => e.fmt(f),
+			Self::MissingClosingBrace(e) => e.fmt(f),
+			Self::NoSuchVariable(e) => e.fmt(f),
 		}
 	}
 }
 
+/// The input string contains an invalid escape sequence.
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct InvalidEscapeSequence {
+	/// The byte offset within the input where the error occurs.
+	///
+	/// This points to the associated backslash character in the source text.
+	pub position: usize,
+
+	/// The byte value of the invalid escape sequence.
+	pub character: Option<u8>,
+}
+
+impl std::error::Error for InvalidEscapeSequence {}
+
+impl std::fmt::Display for InvalidEscapeSequence {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		if let Some(c) = self.character {
+			write!(f, "Invalid escape sequence: \\{}", char::from(c))
+		} else {
+			write!(f, "Invalid escape sequence: missing escape character")
+		}
+	}
+}
+
+/// The input string contains a variable placeholder without a variable name (`"${}"`).
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct MissingVariableName {
+	/// The byte offset within the input where the error occurs.
+	///
+	/// This points to the `$` sign with a missing variable name in the input text.
+	pub position: usize,
+
+	/// The length of the variable placeholder in bytes.
+	pub len: usize,
+}
+
+impl std::error::Error for MissingVariableName {}
+
+impl std::fmt::Display for MissingVariableName {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "Missing variable name")
+	}
+}
+
+/// The input string contains an unexpected character.
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct UnexpectedCharacter {
+	/// The byte offset within the input where the error occurs.
+	///
+	/// This points to the unexpected character in the input text.
+	pub position: usize,
+
+	/// The byte value of the unexpected character.
+	///
+	/// For multi-byte UTF-8 sequences, this only gives the value of the start byte.
+	/// You can use the `position` to get the full UTF-8 sequence from the original input string.
+	pub character: u8,
+
+	/// A human readable message about what was expected instead.
+	pub expected: ExpectedCharacter,
+}
+
+impl std::error::Error for UnexpectedCharacter {}
+
+impl std::fmt::Display for UnexpectedCharacter {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "Unexpected character: {:?}, expected {}", char::from(self.character), self.expected.message())
+	}
+}
+
+/// A struct to describe what was expected instead of the unexpected character.
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct ExpectedCharacter {
+	/// A human readable message to describe what is expected.
+	pub(crate) message: &'static str,
+}
+
+impl ExpectedCharacter {
+	/// Get a human readable message to describe what was expected.
+	pub fn message(&self) -> &str {
+		self.message
+	}
+}
+
+/// The input string contains an unclosed variable placeholder.
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct MissingClosingBrace {
+	/// The byte offset within the input where the error occurs.
+	///
+	/// This points to the `{` character that is missing a closing brace.
+	pub position: usize,
+}
+
+impl std::error::Error for MissingClosingBrace {}
+
+impl std::fmt::Display for MissingClosingBrace {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "Missing closing brace")
+	}
+}
+
+/// The input string contains a placeholder for a variable that is not in the variable map.
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(Eq, PartialEq))]
+pub struct NoSuchVariable {
+	/// The byte offset within the input where the error occurs.
+	///
+	/// This points to the first character of the name in the input text.
+	pub position: usize,
+
+	/// The name of the variable.
+	pub name: String,
+}
+
+impl std::error::Error for NoSuchVariable {}
+
+impl std::fmt::Display for NoSuchVariable {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "No such variable: ${}", self.name)
+	}
+}
+
 impl Error {
+	/// Get the range in the source text that contains the error.
+	pub fn source_range(&self) -> std::ops::Range<usize> {
+		let (start, len) = match &self {
+			Self::InvalidEscapeSequence(e) => {
+				if e.character.is_some() {
+					(e.position, 2)
+				} else {
+					(e.position, 1)
+				}
+			},
+			Self::MissingVariableName(e) => {
+				(e.position, e.len)
+			},
+			Self::UnexpectedCharacter(e) => {
+				(e.position, 1)
+			},
+			Self::MissingClosingBrace(e) => {
+				(e.position, 1)
+			},
+			Self::NoSuchVariable(e) => {
+				(e.position, e.name.len())
+			},
+		};
+		std::ops::Range {
+			start,
+			end: start + len,
+		}
+	}
+
+	/// Get the line of source that contains the error.
+	///
+	/// # Panics
+	/// May panic if the source text is not the original source that contains the error.
+	pub fn source_line<'a>(&self, source: &'a [u8]) -> &'a [u8] {
+		let position = self.source_range().start;
+		let start = line_start(source, position);
+		let end = line_end(source, position);
+		&source[start..end]
+	}
+
 	/// Write source highlighting for the error location.
 	///
 	/// The highlighting ends with a newline.
+	///
+	/// Note: this function doesn't print anything if the source line exceeds 60 characters in width.
+	/// For more control over this behaviour, consider using [`Self::source_range()`] and [`Self::source_line()`] instead.
 	pub fn write_source_highlighting(&self, f: &mut impl std::fmt::Write, source: &[u8]) -> std::fmt::Result {
-		let (line, start, len) = match &self.inner {
-			ErrorInner::InvalidEscapeSequence { position, character } => {
-				let line = get_line(source, *position);
-				if character.is_some() {
-					(line, *position, 2)
-				} else {
-					(line, *position, 1)
-				}
-			},
-			ErrorInner::MissingVariableName { position, len } => {
-				(get_line(source, *position), *position, *len)
-			},
-			ErrorInner::UnexpectedCharacter { position, character: _, expected: _ } => {
-				(get_line(source, *position), *position, 1)
-			},
-			ErrorInner::MissingClosingBrace { position } => {
-				(get_line(source, *position), *position, 1)
-			},
-			ErrorInner::NoSuchVariable { position, name } => {
-				(get_line(source, *position), *position, name.len())
-			},
+		use unicode_width::UnicodeWidthStr;
+
+		let range = self.source_range();
+		let line = self.source_line(source);
+		let line = match std::str::from_utf8(line) {
+			Ok(line) => line,
+			Err(_) => return Err(std::fmt::Error),
 		};
-		let line = match line {
-			Ok(line) if line.len() <= 60 => line,
-			_ => return Ok(()),
-		};
+		if line.width() > 60 {
+			return Ok(())
+		}
 		write!(f, "  {}\n  ", line)?;
-		write_underline(f, &line, start, start + len)?;
+		write_underline(f, line, range)?;
 		writeln!(f)
 	}
 
@@ -125,17 +279,10 @@ fn line_end(source: &[u8], position: usize) -> usize {
 	}
 }
 
-fn get_line(source: &[u8], position: usize) -> Result<String, std::str::Utf8Error> {
-	let start = line_start(source, position);
-	let end = line_end(source, position);
-	let line = std::str::from_utf8(&source[start..end])?.trim();
-	Ok(line.replace('\t', "    "))
-}
-
-fn write_underline(f: &mut impl std::fmt::Write, line: &str, start: usize, end: usize) -> std::fmt::Result {
+fn write_underline(f: &mut impl std::fmt::Write, line: &str, range: std::ops::Range<usize>) -> std::fmt::Result {
 	use unicode_width::UnicodeWidthStr;
-	let spaces = line[..start].width();
-	let carets = line[start..end].width();
+	let spaces = line[..range.start].width();
+	let carets = line[range].width();
 	write!(f, "{}", " ".repeat(spaces))?;
 	write!(f, "{}", "^".repeat(carets))?;
 	Ok(())

--- a/src/map.rs
+++ b/src/map.rs
@@ -17,6 +17,7 @@ pub struct NoSubstitution;
 impl<'a> VariableMap<'a> for NoSubstitution {
 	type Value = NeverValue;
 
+	#[inline]
 	fn get(&'a self, _key: &str) -> Option<Self::Value> {
 		None
 	}
@@ -27,6 +28,7 @@ impl<'a> VariableMap<'a> for NoSubstitution {
 pub enum NeverValue {}
 
 impl<T: ?Sized> AsRef<T> for NeverValue {
+	#[inline]
 	fn as_ref(&self) -> &T {
 		match *self {
 		}
@@ -40,6 +42,7 @@ pub struct Env;
 impl<'a> VariableMap<'a> for Env {
 	type Value = String;
 
+	#[inline]
 	fn get(&'a self, key: &str) -> Option<Self::Value> {
 		std::env::var(key).ok()
 	}
@@ -56,6 +59,7 @@ pub struct EnvBytes;
 impl<'a> VariableMap<'a> for EnvBytes {
 	type Value = Vec<u8>;
 
+	#[inline]
 	fn get(&'a self, key: &str) -> Option<Self::Value> {
 		use std::os::unix::ffi::OsStringExt;
 		let value = std::env::var_os(key)?;
@@ -66,6 +70,7 @@ impl<'a> VariableMap<'a> for EnvBytes {
 impl<'a, V: 'a> VariableMap<'a> for BTreeMap<&str, V> {
 	type Value = &'a V;
 
+	#[inline]
 	fn get(&'a self, key: &str) -> Option<Self::Value> {
 		self.get(key)
 	}
@@ -74,6 +79,7 @@ impl<'a, V: 'a> VariableMap<'a> for BTreeMap<&str, V> {
 impl<'a, V: 'a> VariableMap<'a> for BTreeMap<String, V> {
 	type Value = &'a V;
 
+	#[inline]
 	fn get(&'a self, key: &str) -> Option<Self::Value> {
 		self.get(key)
 	}
@@ -82,6 +88,7 @@ impl<'a, V: 'a> VariableMap<'a> for BTreeMap<String, V> {
 impl<'a, V: 'a, S: BuildHasher> VariableMap<'a> for HashMap<&str, V, S> {
 	type Value = &'a V;
 
+	#[inline]
 	fn get(&'a self, key: &str) -> Option<Self::Value> {
 		self.get(key)
 	}
@@ -90,6 +97,7 @@ impl<'a, V: 'a, S: BuildHasher> VariableMap<'a> for HashMap<&str, V, S> {
 impl<'a, V: 'a, S: BuildHasher> VariableMap<'a> for HashMap<String, V, S> {
 	type Value = &'a V;
 
+	#[inline]
 	fn get(&'a self, key: &str) -> Option<Self::Value> {
 		self.get(key)
 	}

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -57,12 +57,14 @@ pub enum Error {
 }
 
 impl From<serde_yaml::Error> for Error {
+	#[inline]
 	fn from(other: serde_yaml::Error) -> Self {
 		Self::Yaml(other)
 	}
 }
 
 impl From<crate::Error> for Error {
+	#[inline]
 	fn from(other: crate::Error) -> Self {
 		Self::Subst(other)
 	}
@@ -71,6 +73,7 @@ impl From<crate::Error> for Error {
 impl std::error::Error for Error {}
 
 impl std::fmt::Display for Error {
+	#[inline]
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			Error::Yaml(e) => std::fmt::Display::fmt(e, f),


### PR DESCRIPTION
This PR is partially based on #8. When I was testing the UTF-8 fix introduced in #8, I accidently found two entirely new ways for the code to slice inside char boundaries and panic. Feeling the current approach was too brittle, I wanted to try my hand at addressing the issue in a more fundamental way, and this is the result. I know it's a big change and you might prefer something less, er, overhaul-ish :sweat_smile:.

Unfortunately I forgot how to reproduce the aforementioned bugs, since it's been a few days……But I have added unicode tests for all situations I can think of, so it should be alright…

The only breaking change introduced is making `write_source_highlighting()` accept `&str`, since logically we can't really format non-UTF8 error messages without significantly more effort anyway.

This is currently marked draft, because I think I can find a way to get rid of the `bstr` dependency. I'm also a bit unhappy with how error positions are tracked with this approach, and would love to hear any suggestions.