### PR TITLE
Some linting and minor upgrades

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ publish = ["crates-io"]
 keywords = ["substitution", "expansion", "variable", "parameter", "shell"]
 categories = ["template-engine", "value-formatting"]
 
-edition = "2018"
+edition = "2021"
 
 [features]
-yaml = ["serde", "serde_yaml"]
+yaml = ["dep:serde", "dep:serde_yaml"]
 
 [dependencies]
 memchr = "2.4.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,7 +86,6 @@ impl CharOrByte {
 	/// For [`Self::Char`], this returns the UTF-8 lengths of the character.
 	/// For [`Self::Byte`], this is always returns 1.
 	#[inline]
-	#[must_use]
 	pub fn source_len(&self) -> usize {
 		match self {
 			Self::Char(c) => c.len_utf8(),
@@ -97,7 +96,6 @@ impl CharOrByte {
 	/// Return a printable version of `self` for error messages.
 	///
 	/// The returned value implements `Display` and is suitable for inclusion in error messages.
-	#[must_use]
 	pub fn quoted_printable(&self) -> impl std::fmt::Display {
 		#[derive(Copy, Clone, Debug)]
 		struct QuotedPrintable {
@@ -237,7 +235,6 @@ pub struct ExpectedCharacter {
 impl ExpectedCharacter {
 	/// Get a human readable message to describe what was expected.
 	#[inline]
-	#[must_use]
 	pub fn message(&self) -> &str {
 		self.message
 	}
@@ -287,7 +284,6 @@ impl std::fmt::Display for NoSuchVariable {
 impl Error {
 	/// Get the range in the source text that contains the error.
 	#[inline]
-	#[must_use]
 	pub fn source_range(&self) -> std::ops::Range<usize> {
 		let (start, len) = match &self {
 			Self::InvalidEscapeSequence(e) => {
@@ -310,7 +306,6 @@ impl Error {
 	/// # Panics
 	/// May panic if the source text is not the original source that contains the error.
 	#[inline]
-	#[must_use]
 	pub fn source_line<'a>(&self, source: &'a str) -> &'a str {
 		let position = self.source_range().start;
 		let start = line_start(source, position);
@@ -344,7 +339,6 @@ impl Error {
 	///
 	/// Note: this function returns an empty string if the source line exceeds 60 characters in width.
 	#[inline]
-	#[must_use]
 	pub fn source_highlighting(&self, source: &str) -> String {
 		let mut output = String::new();
 		self.write_source_highlighting(&mut output, source).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,8 @@ where
 					return Err(error::NoSuchVariable {
 						position: variable.name_start,
 						name: variable.name.to_owned(),
-					})?;
+					}
+					.into());
 				},
 				(Some(value), _default) => {
 					output.extend_from_slice(to_bytes(value));
@@ -182,7 +183,8 @@ fn parse_variable(source: &[u8], finger: usize) -> Result<Variable, Error> {
 		return Err(error::MissingVariableName {
 			position: finger,
 			len: 1,
-		})?;
+		}
+		.into());
 	}
 	if source[finger + 1] == b'{' {
 		parse_braced_variable(source, finger)
@@ -195,7 +197,8 @@ fn parse_variable(source: &[u8], finger: usize) -> Result<Variable, Error> {
 				return Err(error::MissingVariableName {
 					position: finger,
 					len: 1,
-				})?;
+				}
+				.into());
 			},
 			Some(x) => finger + 1 + x,
 			None => source.len(),
@@ -218,7 +221,8 @@ fn parse_braced_variable(source: &[u8], finger: usize) -> Result<Variable, Error
 		return Err(error::MissingVariableName {
 			position: finger,
 			len: 2,
-		})?;
+		}
+		.into());
 	}
 
 	// Get the first sequence of alphanumeric characters and underscores for the variable name.
@@ -230,7 +234,8 @@ fn parse_braced_variable(source: &[u8], finger: usize) -> Result<Variable, Error
 			return Err(error::MissingVariableName {
 				position: finger,
 				len: 2,
-			})?;
+			}
+			.into());
 		},
 		Some(x) => name_start + x,
 		None => source.len(),
@@ -238,7 +243,7 @@ fn parse_braced_variable(source: &[u8], finger: usize) -> Result<Variable, Error
 
 	// If the name extends to the end, we're missing a closing brace.
 	if name_end == source.len() {
-		return Err(error::MissingClosingBrace { position: finger + 1 })?;
+		return Err(error::MissingClosingBrace { position: finger + 1 }.into());
 	}
 
 	// If there is a closing brace after the name, there is no default value and we're done.
@@ -258,7 +263,8 @@ fn parse_braced_variable(source: &[u8], finger: usize) -> Result<Variable, Error
 			expected: error::ExpectedCharacter {
 				message: "a closing brace ('}') or colon (':')",
 			},
-		})?;
+		}
+		.into());
 	}
 
 	// If there is no un-escaped closing brace, it's missing.
@@ -296,7 +302,7 @@ fn get_maybe_char_at(data: &[u8], index: usize) -> error::CharOrByte {
 		!head.is_empty(),
 		"index out of bounds: data.len() is {} but index is {}",
 		data.len(),
-		index
+		index,
 	);
 
 	let head = valid_utf8_prefix(head);
@@ -335,7 +341,8 @@ fn unescape_one(source: &[u8], position: usize) -> Result<u8, Error> {
 		return Err(error::InvalidEscapeSequence {
 			position,
 			character: None,
-		})?;
+		}
+		.into());
 	}
 	match source[position + 1] {
 		b'\\' => Ok(b'\\'),
@@ -346,7 +353,8 @@ fn unescape_one(source: &[u8], position: usize) -> Result<u8, Error> {
 		_ => Err(error::InvalidEscapeSequence {
 			position,
 			character: Some(get_maybe_char_at(source, position + 1)),
-		})?,
+		}
+		.into()),
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,10 +141,9 @@ where
 					return Err(error::NoSuchVariable {
 						position: variable.name_start,
 						name: variable.name.to_owned(),
-					}
-					.into())
+					})?;
 				},
-				(Some(value), _) => {
+				(Some(value), _default) => {
 					output.extend_from_slice(to_bytes(value));
 				},
 				(None, Some(default)) => {
@@ -183,8 +182,7 @@ fn parse_variable(source: &[u8], finger: usize) -> Result<Variable, Error> {
 		return Err(error::MissingVariableName {
 			position: finger,
 			len: 1,
-		}
-		.into());
+		})?;
 	}
 	if source[finger + 1] == b'{' {
 		parse_braced_variable(source, finger)
@@ -197,8 +195,7 @@ fn parse_variable(source: &[u8], finger: usize) -> Result<Variable, Error> {
 				return Err(error::MissingVariableName {
 					position: finger,
 					len: 1,
-				}
-				.into())
+				})?;
 			},
 			Some(x) => finger + 1 + x,
 			None => source.len(),
@@ -221,8 +218,7 @@ fn parse_braced_variable(source: &[u8], finger: usize) -> Result<Variable, Error
 		return Err(error::MissingVariableName {
 			position: finger,
 			len: 2,
-		}
-		.into());
+		})?;
 	}
 
 	// Get the first sequence of alphanumeric characters and underscores for the variable name.
@@ -234,8 +230,7 @@ fn parse_braced_variable(source: &[u8], finger: usize) -> Result<Variable, Error
 			return Err(error::MissingVariableName {
 				position: finger,
 				len: 2,
-			}
-			.into())
+			})?;
 		},
 		Some(x) => name_start + x,
 		None => source.len(),
@@ -243,7 +238,7 @@ fn parse_braced_variable(source: &[u8], finger: usize) -> Result<Variable, Error
 
 	// If the name extends to the end, we're missing a closing brace.
 	if name_end == source.len() {
-		return Err(error::MissingClosingBrace { position: finger + 1 }.into());
+		return Err(error::MissingClosingBrace { position: finger + 1 })?;
 	}
 
 	// If there is a closing brace after the name, there is no default value and we're done.
@@ -263,8 +258,7 @@ fn parse_braced_variable(source: &[u8], finger: usize) -> Result<Variable, Error
 			expected: error::ExpectedCharacter {
 				message: "a closing brace ('}') or colon (':')",
 			},
-		}
-		.into());
+		})?;
 	}
 
 	// If there is no un-escaped closing brace, it's missing.
@@ -341,8 +335,7 @@ fn unescape_one(source: &[u8], position: usize) -> Result<u8, Error> {
 		return Err(error::InvalidEscapeSequence {
 			position,
 			character: None,
-		}
-		.into());
+		})?;
 	}
 	match source[position + 1] {
 		b'\\' => Ok(b'\\'),
@@ -353,12 +346,12 @@ fn unescape_one(source: &[u8], position: usize) -> Result<u8, Error> {
 		_ => Err(error::InvalidEscapeSequence {
 			position,
 			character: Some(get_maybe_char_at(source, position + 1)),
-		}
-		.into()),
+		})?,
 	}
 }
 
 #[cfg(test)]
+#[rustfmt::skip]
 mod test {
 	use super::*;
 	use assert2::{assert, check, let_assert};
@@ -367,6 +360,7 @@ mod test {
 	#[test]
 	fn test_get_maybe_char_at() {
 		use error::CharOrByte::{Byte, Char};
+
 		assert!(get_maybe_char_at(b"hello", 0) == Char('h'));
 		assert!(get_maybe_char_at(b"he", 0) == Char('h'));
 		assert!(get_maybe_char_at(b"hello", 1) == Char('e'));

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -4,7 +4,7 @@ use serde::de::DeserializeOwned;
 
 use crate::VariableMap;
 
-/// Parse a struct from YAML data, after perfoming variable substitution on string values.
+/// Parse a struct from YAML data, after performing variable substitution on string values.
 ///
 /// This function first parses the data into a [`serde_yaml::Value`],
 /// then performs variable substitution on all string values,
@@ -19,7 +19,7 @@ where
 	Ok(serde_yaml::from_value(value)?)
 }
 
-/// Parse a struct from YAML data, after perfoming variable substitution on string values.
+/// Parse a struct from YAML data, after performing variable substitution on string values.
 ///
 /// This function first parses the data into a [`serde_yaml::Value`],
 /// then performs variable substitution on all string values,
@@ -49,10 +49,10 @@ where
 /// Error for parsing YAML with variable substitution.
 #[derive(Debug)]
 pub enum Error {
-	/// An error occured while parsing YAML.
+	/// An error occurred while parsing YAML.
 	Yaml(serde_yaml::Error),
 
-	/// An error occured while performing variable substitution.
+	/// An error occurred while performing variable substitution.
 	Subst(crate::Error),
 }
 
@@ -88,9 +88,7 @@ where
 	F: Copy + Fn(&mut String) -> Result<(), E>,
 {
 	match value {
-		serde_yaml::Value::Null => Ok(()),
-		serde_yaml::Value::Bool(_) => Ok(()),
-		serde_yaml::Value::Number(_) => Ok(()),
+		serde_yaml::Value::Null | serde_yaml::Value::Bool(_) | serde_yaml::Value::Number(_) => Ok(()),
 		serde_yaml::Value::String(val) => fun(val),
 		serde_yaml::Value::Tagged(tagged) => visit_string_values(&mut tagged.value, fun),
 		serde_yaml::Value::Sequence(seq) => {
@@ -100,7 +98,7 @@ where
 			Ok(())
 		},
 		serde_yaml::Value::Mapping(map) => {
-			for (_key, value) in map.iter_mut() {
+			for value in map.values_mut() {
 				visit_string_values(value, fun)?;
 			}
 			Ok(())
@@ -109,6 +107,7 @@ where
 }
 
 #[cfg(test)]
+#[rustfmt::skip]
 mod test {
 	use std::collections::HashMap;
 

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -88,7 +88,9 @@ where
 	F: Copy + Fn(&mut String) -> Result<(), E>,
 {
 	match value {
-		serde_yaml::Value::Null | serde_yaml::Value::Bool(_) | serde_yaml::Value::Number(_) => Ok(()),
+		serde_yaml::Value::Null => Ok(()),
+		serde_yaml::Value::Bool(_) => Ok(()),
+		serde_yaml::Value::Number(_) => Ok(()),
 		serde_yaml::Value::String(val) => fun(val),
 		serde_yaml::Value::Tagged(tagged) => visit_string_values(&mut tagged.value, fun),
 		serde_yaml::Value::Sequence(seq) => {


### PR DESCRIPTION
* Fixed some spelling
* Migrate to edition 2021
* Use `dep:` syntax in Cargo.toml to avoid creating implicit features
* Fix a number of clippy suggestions (must_use, inline format args, map_or,
* run `cargo +nightly fmt` to keep code consistently formatted
* Marked some code blocks as `#[rustfmt::skip]`
* Use the `?` operator instead of `.into()` for error returning

P.S. this is the very first Rust project I saw that uses TABs...  Your choice of course, but i was a bit surprised :)