### PR TITLE
Implement `VariableMap` for `Vec<AsRef<str>>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,4 +370,19 @@ mod test {
 				r"            ^^^", "\n",
 		));
 	}
+
+	#[test]
+	fn test_vec_map() {
+		let test_vec = vec!["xxxx", "foo", "bar"];
+		let test_slice = &test_vec[..];
+		let_assert!(Err(e) = substitute("${99}", &test_slice));
+		assert!(e.to_string() == "No such variable: $99");
+		assert_eq!(Ok("foo bar"), substitute("${*}", &test_slice).as_deref());
+		assert_eq!(Ok("xxxx"), substitute("${0}", &test_slice).as_deref());
+		assert_eq!(Ok("foo"), substitute("${1}", &test_slice).as_deref());
+		assert_eq!(Ok("bar"), substitute("${2}", &test_slice).as_deref());
+		assert_eq!(Ok("foo bar"), substitute("$*", &test_slice).as_deref());
+		assert_eq!(Ok("foo"), substitute("$1", &test_slice).as_deref());
+		assert_eq!(Ok("bar"), substitute("$2", &test_slice).as_deref());
+	}
 }

--- a/src/template/raw/parse.rs
+++ b/src/template/raw/parse.rs
@@ -60,6 +60,13 @@ impl Variable {
 		}
 		if source[finger + 1] == b'{' {
 			Self::parse_braced(source, finger)
+		} else if source[finger + 1] == b'*' {
+			let name_end = finger + 2;
+			let variable = Variable {
+				name: finger + 1..name_end,
+				default: None,
+			};
+			Ok((variable, name_end))
 		} else {
 			let name_end = match source[finger + 1..]
 				.iter()
@@ -101,7 +108,7 @@ impl Variable {
 		// Get the first sequence of alphanumeric characters and underscores for the variable name.
 		let name_end = match source[name_start..]
 			.iter()
-			.position(|&c| !c.is_ascii_alphanumeric() && c != b'_')
+			.position(|&c| !c.is_ascii_alphanumeric() && c != b'_' && c != b'*')
 		{
 			Some(0) => {
 				return Err(error::MissingVariableName {
@@ -117,6 +124,14 @@ impl Variable {
 		// If the name extends to the end, we're missing a closing brace.
 		if name_end == source.len() {
 			return Err(error::MissingClosingBrace { position: finger + 1 }.into());
+		}
+
+		if name_end - name_start > 1 && source[name_start..name_end].contains(&b'*') {
+			return Err(error::MissingVariableName {
+				position: finger,
+				len: name_end - name_start,
+			}
+			.into());
 		}
 
 		// If there is a closing brace after the name, there is no default value and we're done.
@@ -140,8 +155,8 @@ impl Variable {
 		}
 
 		// If there is no matching un-escaped closing brace, it's missing.
-		let end = finger + find_closing_brace(&source[finger..])
-			.ok_or(error::MissingClosingBrace { position: finger + 1 })?;
+		let end = finger
+			+ find_closing_brace(&source[finger..]).ok_or(error::MissingClosingBrace { position: finger + 1 })?;
 
 		let variable = Variable {
 			name: name_start..name_end,


### PR DESCRIPTION
This implements `VariableMap` for `&[T]` slices containing strings (`T: AsRef<str>`).

In addition to this, the parser is updated to allow a single `*` as variable name. This is used in above's `VariableMap` implementation to make `$*` and `${*}` substitute to the concatenation of all variables but `$0, like a shell would do.

My use-case for this is too take an argument list like argv, and then use subst to replace those numbered arguments within a string.

