### PR TITLE
fix: properly handle `$` at end of input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,14 @@ mod test {
 				r"  Hello 　$❤", "\n",
 				r"          ^", "\n",
 		));
+		let source = r"Hello 　$";
+		let_assert!(Err(e) = substitute(source, &map));
+		assert!(e.to_string() == r"Missing variable name");
+		#[rustfmt::skip]
+		assert!(e.source_highlighting(source) == concat!(
+				r"  Hello 　$", "\n",
+				r"          ^", "\n",
+		));
 	}
 
 	#[test]

--- a/src/template/raw/parse.rs
+++ b/src/template/raw/parse.rs
@@ -51,7 +51,7 @@ impl Variable {
 	///
 	/// Returns the parsed variable and the index of the byte after the variable.
 	fn parse(source: &[u8], finger: usize) -> Result<(Self, usize), ParseError> {
-		if finger == source.len() {
+		if finger + 1 >= source.len() {
 			return Err(error::MissingVariableName {
 				position: finger,
 				len: 1,
@@ -140,8 +140,8 @@ impl Variable {
 		}
 
 		// If there is no matching un-escaped closing brace, it's missing.
-		let end = finger + find_closing_brace(&source[finger..])
-			.ok_or(error::MissingClosingBrace { position: finger + 1 })?;
+		let end = finger
+			+ find_closing_brace(&source[finger..]).ok_or(error::MissingClosingBrace { position: finger + 1 })?;
 
 		let variable = Variable {
 			name: name_start..name_end,


### PR DESCRIPTION
... prevents panics like this:

```
thread 'main' panicked at /home/xxx/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/subst-0.3.7/src/template/raw/parse.rs:61:12:
index out of bounds: the len is 1 but the index is 1
