### PR TITLE
feat(serde): Enable serialization & deserialization for `Template*`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,19 +18,21 @@ edition = "2021"
 indexmap = ["dep:indexmap"]
 
 # Enable support for performing substitution in all string values of a JSON document.
-json = ["dep:serde", "dep:serde_json"]
+json = ["serde", "dep:serde_json"]
 
 # Enable support for performing substitution in all string values of a TOML document.
-toml = ["dep:serde", "dep:toml"]
+toml = ["serde", "dep:toml"]
 
 # Enable support for performing substitution in all string values of a YAML document.
-yaml = ["dep:serde", "dep:serde_yaml"]
+yaml = ["serde", "dep:serde_yaml"]
 
 # Preserve the order of fields in JSON objects and TOML tables (YAML always preserves the order).
 preserve-order = ["toml?/preserve_order", "serde_json?/preserve_order"]
 
 # Enable #[doc(cfg...)] annotations for optional parts of the library (requires a nightly compiler).
 doc-cfg = []
+
+serde = [ "dep:serde" ]
 
 [dependencies]
 indexmap = { version = "2.5.0", optional = true }
@@ -45,6 +47,7 @@ unicode-width = "0.1.9"
 assert2 = "0.3.6"
 subst = { path = ".", features = ["json", "toml", "yaml"] }
 serde = { version = "1.0.0", features = ["derive"] }
+serde_test = "1.0.177"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ edition = "2021"
 # Implement `VariableMap` for `indexmap::IndexMap`.
 indexmap = ["dep:indexmap"]
 
+# Enable serde Deserialize and Serialize implementations for templates.
+serde = ["dep:serde"]
+
 # Enable support for performing substitution in all string values of a JSON document.
 json = ["serde", "dep:serde_json"]
 
@@ -31,8 +34,6 @@ preserve-order = ["toml?/preserve_order", "serde_json?/preserve_order"]
 
 # Enable #[doc(cfg...)] annotations for optional parts of the library (requires a nightly compiler).
 doc-cfg = []
-
-serde = [ "dep:serde" ]
 
 [dependencies]
 indexmap = { version = "2.5.0", optional = true }

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -13,3 +13,8 @@ pub mod yaml;
 #[cfg(feature = "toml")]
 #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "toml")))]
 pub mod toml;
+
+// This module isn't expected, since it only defines trait implementations.
+#[cfg(feature = "serde")]
+#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "serde")))]
+mod serde;

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -1,0 +1,219 @@
+use std::marker::PhantomData;
+
+use serde::{
+	de::{Error, Visitor},
+	Deserialize,
+	Deserializer,
+	Serialize,
+	Serializer,
+};
+
+use crate::{ByteTemplate, ByteTemplateBuf, Template, TemplateBuf};
+
+struct TemplateVisitor<'de> {
+	_lifetime: PhantomData<&'de ()>,
+}
+
+impl<'de> TemplateVisitor<'de> {
+	const fn new() -> Self {
+		Self { _lifetime: PhantomData }
+	}
+}
+
+impl<'de> Visitor<'de> for TemplateVisitor<'de> {
+	type Value = Template<'de>;
+
+	fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Template::from_str(v).map_err(E::custom)
+	}
+
+	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+		formatter.write_str("a borrowed string")
+	}
+}
+
+struct TemplateBufVisitor;
+
+impl<'de> Visitor<'de> for TemplateBufVisitor {
+	type Value = TemplateBuf;
+
+	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+		formatter.write_str("a string")
+	}
+
+	fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		self.visit_string(v.to_owned())
+	}
+
+	fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		TemplateBuf::from_string(v).map_err(E::custom)
+	}
+}
+
+struct ByteTemplateVisitor<'de> {
+	_lifetime: PhantomData<&'de ()>,
+}
+
+impl<'de> ByteTemplateVisitor<'de> {
+	const fn new() -> Self {
+		Self { _lifetime: PhantomData }
+	}
+}
+
+impl<'de> Visitor<'de> for ByteTemplateVisitor<'de> {
+	type Value = ByteTemplate<'de>;
+
+	fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		ByteTemplate::from_slice(v).map_err(E::custom)
+	}
+
+	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+		formatter.write_str("a borrowed string")
+	}
+}
+
+struct ByteTemplateBufVisitor;
+
+impl<'de> Visitor<'de> for ByteTemplateBufVisitor {
+	type Value = ByteTemplateBuf;
+
+	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+		formatter.write_str("a string")
+	}
+
+	fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		self.visit_byte_buf(v.to_vec())
+	}
+
+	fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		ByteTemplateBuf::from_vec(v).map_err(E::custom)
+	}
+}
+
+impl Serialize for Template<'_> {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_str(self.source())
+	}
+}
+
+impl Serialize for TemplateBuf {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_str(self.as_template().source())
+	}
+}
+
+impl Serialize for ByteTemplate<'_> {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_bytes(self.source())
+	}
+}
+
+impl Serialize for ByteTemplateBuf {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_bytes(self.as_template().source())
+	}
+}
+
+impl<'de> Deserialize<'de> for Template<'de> {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_str(TemplateVisitor::new())
+	}
+}
+
+impl<'de> Deserialize<'de> for TemplateBuf {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_string(TemplateBufVisitor)
+	}
+}
+
+impl<'de> Deserialize<'de> for ByteTemplate<'de> {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_bytes(ByteTemplateVisitor::new())
+	}
+}
+
+impl<'de> Deserialize<'de> for ByteTemplateBuf {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_string(ByteTemplateBufVisitor)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use serde_test::{assert_tokens, Token};
+
+	use crate::{ByteTemplate, ByteTemplateBuf, Template, TemplateBuf};
+
+	const STR_SOURCE: &str = "{hello}";
+	const BYTE_SOURCE: &[u8] = b"{hello}";
+
+	#[test]
+	fn template_ser_de() {
+		let template = Template::from_str(STR_SOURCE).unwrap();
+
+		assert_tokens(&template, &[Token::BorrowedStr(STR_SOURCE)]);
+	}
+
+	#[test]
+	fn template_buf_ser_de() {
+		let template = TemplateBuf::from_string(STR_SOURCE.to_string()).unwrap();
+
+		assert_tokens(&template, &[Token::String(STR_SOURCE)]);
+	}
+
+	#[test]
+	fn byte_template_ser_de() {
+		let template = ByteTemplate::from_slice(BYTE_SOURCE).unwrap();
+
+		assert_tokens(&template, &[Token::BorrowedBytes(BYTE_SOURCE)]);
+	}
+
+	#[test]
+	fn byte_template_buf_ser_de() {
+		let template = ByteTemplateBuf::from_vec(BYTE_SOURCE.to_vec()).unwrap();
+
+		assert_tokens(&template, &[Token::ByteBuf(BYTE_SOURCE)]);
+	}
+}

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -1,112 +1,10 @@
-use std::marker::PhantomData;
-
-use serde::{
-	de::{Error, Visitor},
-	Deserialize,
-	Deserializer,
-	Serialize,
-	Serializer,
-};
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+use serde::de::Error;
 
 use crate::{ByteTemplate, ByteTemplateBuf, Template, TemplateBuf};
-
-struct TemplateVisitor<'de> {
-	_lifetime: PhantomData<&'de ()>,
-}
-
-impl<'de> TemplateVisitor<'de> {
-	const fn new() -> Self {
-		Self { _lifetime: PhantomData }
-	}
-}
-
-impl<'de> Visitor<'de> for TemplateVisitor<'de> {
-	type Value = Template<'de>;
-
-	fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-	where
-		E: Error,
-	{
-		Template::from_str(v).map_err(E::custom)
-	}
-
-	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-		formatter.write_str("a borrowed string")
-	}
-}
-
-struct TemplateBufVisitor;
-
-impl<'de> Visitor<'de> for TemplateBufVisitor {
-	type Value = TemplateBuf;
-
-	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-		formatter.write_str("a string")
-	}
-
-	fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-	where
-		E: Error,
-	{
-		self.visit_string(v.to_owned())
-	}
-
-	fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-	where
-		E: Error,
-	{
-		TemplateBuf::from_string(v).map_err(E::custom)
-	}
-}
-
-struct ByteTemplateVisitor<'de> {
-	_lifetime: PhantomData<&'de ()>,
-}
-
-impl<'de> ByteTemplateVisitor<'de> {
-	const fn new() -> Self {
-		Self { _lifetime: PhantomData }
-	}
-}
-
-impl<'de> Visitor<'de> for ByteTemplateVisitor<'de> {
-	type Value = ByteTemplate<'de>;
-
-	fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
-	where
-		E: Error,
-	{
-		ByteTemplate::from_slice(v).map_err(E::custom)
-	}
-
-	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-		formatter.write_str("a borrowed string")
-	}
-}
-
-struct ByteTemplateBufVisitor;
-
-impl<'de> Visitor<'de> for ByteTemplateBufVisitor {
-	type Value = ByteTemplateBuf;
-
-	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-		formatter.write_str("a string")
-	}
-
-	fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-	where
-		E: Error,
-	{
-		self.visit_byte_buf(v.to_vec())
-	}
-
-	fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
-	where
-		E: Error,
-	{
-		ByteTemplateBuf::from_vec(v).map_err(E::custom)
-	}
-}
 
 impl Serialize for Template<'_> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -149,7 +47,8 @@ impl<'de> Deserialize<'de> for Template<'de> {
 	where
 		D: Deserializer<'de>,
 	{
-		deserializer.deserialize_str(TemplateVisitor::new())
+		let source: &'de str = Deserialize::deserialize(deserializer)?;
+		Self::from_str(source).map_err(D::Error::custom)
 	}
 }
 
@@ -158,7 +57,8 @@ impl<'de> Deserialize<'de> for TemplateBuf {
 	where
 		D: Deserializer<'de>,
 	{
-		deserializer.deserialize_string(TemplateBufVisitor)
+		let source: String = Deserialize::deserialize(deserializer)?;
+		Self::from_string(source).map_err(D::Error::custom)
 	}
 }
 
@@ -167,7 +67,8 @@ impl<'de> Deserialize<'de> for ByteTemplate<'de> {
 	where
 		D: Deserializer<'de>,
 	{
-		deserializer.deserialize_bytes(ByteTemplateVisitor::new())
+		let source: &'de [u8] = Deserialize::deserialize(deserializer)?;
+		Self::from_slice(source).map_err(D::Error::custom)
 	}
 }
 
@@ -176,44 +77,54 @@ impl<'de> Deserialize<'de> for ByteTemplateBuf {
 	where
 		D: Deserializer<'de>,
 	{
-		deserializer.deserialize_string(ByteTemplateBufVisitor)
+		struct ByteBufVisitor;
+		impl<'de> serde::de::Visitor<'de> for ByteBufVisitor {
+			type Value = Vec<u8>;
+			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+				write!(formatter, "bytes")
+			}
+			fn visit_bytes<E: Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+				Ok(v.to_vec())
+			}
+			fn visit_byte_buf<E: Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+				Ok(v)
+			}
+		}
+
+		let source = deserializer.deserialize_byte_buf(ByteBufVisitor)?;
+		Self::from_vec(source).map_err(D::Error::custom)
 	}
 }
 
 #[cfg(test)]
 mod test {
+	use crate::{ByteTemplate, ByteTemplateBuf, Template, TemplateBuf};
+	use assert2::let_assert;
 	use serde_test::{assert_tokens, Token};
 
-	use crate::{ByteTemplate, ByteTemplateBuf, Template, TemplateBuf};
-
-	const STR_SOURCE: &str = "{hello}";
-	const BYTE_SOURCE: &[u8] = b"{hello}";
+	const SOURCE: &str = "Hello $name";
 
 	#[test]
 	fn template_ser_de() {
-		let template = Template::from_str(STR_SOURCE).unwrap();
-
-		assert_tokens(&template, &[Token::BorrowedStr(STR_SOURCE)]);
+		let_assert!(Ok(template) = Template::from_str(SOURCE));
+		assert_tokens(&template, &[Token::BorrowedStr(SOURCE)]);
 	}
 
 	#[test]
 	fn template_buf_ser_de() {
-		let template = TemplateBuf::from_string(STR_SOURCE.to_string()).unwrap();
-
-		assert_tokens(&template, &[Token::String(STR_SOURCE)]);
+		let_assert!(Ok(template) = TemplateBuf::from_string(SOURCE.into()));
+		assert_tokens(&template, &[Token::String(SOURCE)]);
 	}
 
 	#[test]
 	fn byte_template_ser_de() {
-		let template = ByteTemplate::from_slice(BYTE_SOURCE).unwrap();
-
-		assert_tokens(&template, &[Token::BorrowedBytes(BYTE_SOURCE)]);
+		let_assert!(Ok(template) = ByteTemplate::from_slice(SOURCE.as_bytes()));
+		assert_tokens(&template, &[Token::BorrowedBytes(SOURCE.as_bytes())]);
 	}
 
 	#[test]
 	fn byte_template_buf_ser_de() {
-		let template = ByteTemplateBuf::from_vec(BYTE_SOURCE.to_vec()).unwrap();
-
-		assert_tokens(&template, &[Token::ByteBuf(BYTE_SOURCE)]);
+		let_assert!(Ok(template) = ByteTemplateBuf::from_vec(SOURCE.as_bytes().to_vec()));
+		serde_test::assert_tokens(&template, &[Token::ByteBuf(SOURCE.as_bytes())]);
 	}
 }

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -1,8 +1,8 @@
 use core::pin::Pin;
 
-use crate::VariableMap;
 use crate::error::{ExpandError, ParseError};
 use crate::non_aliasing::NonAliasing;
+use crate::VariableMap;
 
 mod raw;
 
@@ -28,6 +28,15 @@ impl std::fmt::Debug for Template<'_> {
 		f.debug_tuple("Template").field(&self.source).finish()
 	}
 }
+
+impl std::cmp::PartialEq for Template<'_> {
+	#[inline]
+	fn eq(&self, other: &Self) -> bool {
+		self.source == other.source
+	}
+}
+
+impl std::cmp::Eq for Template<'_> {}
 
 impl<'a> Template<'a> {
 	/// Parse a template from a string slice.
@@ -109,19 +118,13 @@ impl Clone for TemplateBuf {
 		let source = self.source.clone();
 		let raw = self.template.inner().raw.clone();
 
-		let template = Template {
-			raw,
-			source: &*source,
-		};
+		let template = Template { raw, source: &*source };
 		// SAFETY: The str slice given to `template` must remain valid.
 		// Since `String` keeps data on the heap, it remains valid when the `source` is moved.
 		// We MUST ensure we do not modify, drop or overwrite `source`.
 		let template = unsafe { template.transmute_lifetime() };
 		let template = NonAliasing::new(template);
-		Self {
-			template,
-			source,
-		}
+		Self { template, source }
 	}
 }
 
@@ -133,6 +136,14 @@ impl std::fmt::Debug for TemplateBuf {
 			.finish()
 	}
 }
+
+impl std::cmp::PartialEq for TemplateBuf {
+	fn eq(&self, other: &Self) -> bool {
+		self.as_template() == other.as_template()
+	}
+}
+
+impl std::cmp::Eq for TemplateBuf {}
 
 impl TemplateBuf {
 	/// Parse a template from a string.
@@ -256,6 +267,15 @@ impl std::fmt::Debug for ByteTemplate<'_> {
 	}
 }
 
+impl std::cmp::PartialEq for ByteTemplate<'_> {
+	#[inline]
+	fn eq(&self, other: &Self) -> bool {
+		self.source == other.source
+	}
+}
+
+impl std::cmp::Eq for ByteTemplate<'_> {}
+
 impl<'a> ByteTemplate<'a> {
 	/// Parse a template from a byte slice.
 	///
@@ -333,10 +353,7 @@ impl Clone for ByteTemplateBuf {
 		let source = self.source.clone();
 		let raw = self.template.inner().raw.clone();
 
-		let template = ByteTemplate {
-			raw,
-			source: &*source,
-		};
+		let template = ByteTemplate { raw, source: &*source };
 
 		// SAFETY: The slice given to `template` must remain valid.
 		// Since `Pin<Vec<u8>>` keeps data on the heap, it remains valid when the `source` is moved.
@@ -344,10 +361,7 @@ impl Clone for ByteTemplateBuf {
 		let template = unsafe { template.transmute_lifetime() };
 		let template = NonAliasing::new(template);
 
-		Self {
-			template,
-			source,
-		}
+		Self { template, source }
 	}
 }
 
@@ -359,6 +373,15 @@ impl std::fmt::Debug for ByteTemplateBuf {
 			.finish()
 	}
 }
+
+impl std::cmp::PartialEq for ByteTemplateBuf {
+	#[inline]
+	fn eq(&self, other: &Self) -> bool {
+		self.as_template() == other.as_template()
+	}
+}
+
+impl std::cmp::Eq for ByteTemplateBuf {}
 
 impl ByteTemplateBuf {
 	/// Parse a template from a vector of bytes.

--- a/src/template/raw/mod.rs
+++ b/src/template/raw/mod.rs
@@ -4,14 +4,14 @@ mod parse;
 /// Raw template that doesn't know track the original source.
 ///
 /// Internally, this keeps a bunch of offsets into the original source.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Template {
 	/// The individual parts that make up the template.
 	parts: Vec<Part>,
 }
 
 /// One piece of a parsed template.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Part {
 	/// A literal string to be used verbatim from the original source.
 	Literal(Literal),
@@ -24,7 +24,7 @@ pub enum Part {
 }
 
 /// A literal string to be used verbatim from the original source.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Literal {
 	/// The range of the literal in the original source.
 	///
@@ -35,7 +35,7 @@ pub struct Literal {
 }
 
 /// An escaped byte.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EscapedByte {
 	/// The escaped byte.
 	///
@@ -44,7 +44,7 @@ pub struct EscapedByte {
 }
 
 /// A variable to be substituted at expansion time.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Variable {
 	/// The range in the source defining the name of the variable.
 	///


### PR DESCRIPTION
- [x] Implement `serde::Serialize` and `serde::Deserialize` for `Template`, `TemplateBuf`, `ByteTemplate` and `ByteTemplateBuf`
- [x] Add `serde` feature to crate, to control implementation of `serde::Serialize` and `serde::Deserialize`
- [x] make `json`, `toml` and `yaml` features respect `serde` feature